### PR TITLE
US 13, PA 452, PA 420, and PA 291 Recentering

### DIFF
--- a/hwy_data/DE/usaus/de.us013.wpt
+++ b/hwy_data/DE/usaus/de.us013.wpt
@@ -57,4 +57,4 @@ BelRd http://www.openstreetmap.org/?lat=39.771203&lon=-75.483933
 US13BusWil_N https://www.openstreetmap.org/?lat=39.801085&lon=-75.460024
 I-495(5) http://www.openstreetmap.org/?lat=39.806063&lon=-75.451441
 DE92 http://www.openstreetmap.org/?lat=39.809830&lon=-75.442107
-DE/PA http://www.openstreetmap.org/?lat=39.811866&lon=-75.433331
+DE/PA http://www.openstreetmap.org/?lat=39.811892&lon=-75.433301

--- a/hwy_data/PA/usapa/pa.pa132.wpt
+++ b/hwy_data/PA/usapa/pa.pa132.wpt
@@ -5,6 +5,7 @@ PA232 http://www.openstreetmap.org/?lat=40.174475&lon=-75.043820
 PA532 http://www.openstreetmap.org/?lat=40.150788&lon=-75.002578
 US1 http://www.openstreetmap.org/?lat=40.129201&lon=-74.968751
 I-276 http://www.openstreetmap.org/?lat=40.126514&lon=-74.963547
+KniRd http://www.openstreetmap.org/?lat=40.104898&lon=-74.950715
 PA513 http://www.openstreetmap.org/?lat=40.096095&lon=-74.945016
 US13 http://www.openstreetmap.org/?lat=40.084144&lon=-74.935201
 I-95 http://www.openstreetmap.org/?lat=40.083524&lon=-74.934684

--- a/hwy_data/PA/usapa/pa.pa232.wpt
+++ b/hwy_data/PA/usapa/pa.pa232.wpt
@@ -1,4 +1,4 @@
-US1/13 http://www.openstreetmap.org/?lat=40.031673&lon=-75.084729
+US1/13 http://www.openstreetmap.org/?lat=40.031685&lon=-75.084729
 PA73 http://www.openstreetmap.org/?lat=40.061255&lon=-75.083509
 RhaSt http://www.openstreetmap.org/?lat=40.077193&lon=-75.085223
 SusRd http://www.openstreetmap.org/?lat=40.096876&lon=-75.091746

--- a/hwy_data/PA/usapa/pa.pa291.wpt
+++ b/hwy_data/PA/usapa/pa.pa291.wpt
@@ -1,15 +1,19 @@
-US13 http://www.openstreetmap.org/?lat=39.828688&lon=-75.400651
-PriSt_S http://www.openstreetmap.org/?lat=39.826630&lon=-75.398365
-US322 http://www.openstreetmap.org/?lat=39.836186&lon=-75.379735
+US13 http://www.openstreetmap.org/?lat=39.828721&lon=-75.400659
++X1 http://www.openstreetmap.org/?lat=39.826666&lon=-75.398355
+HigAve +PriSt_S http://www.openstreetmap.org/?lat=39.830767&lon=-75.390077
+US322 http://www.openstreetmap.org/?lat=39.836151&lon=-75.379780
+KerSt http://www.openstreetmap.org/?lat=39.841954&lon=-75.367619
+EdgAve http://www.openstreetmap.org/?lat=39.845954&lon=-75.360364
 PA320 http://www.openstreetmap.org/?lat=39.849887&lon=-75.355029
-SteLn http://www.openstreetmap.org/?lat=39.865557&lon=-75.316751
-PA420 https://www.openstreetmap.org/?lat=39.866710&lon=-75.300658
-I-95(10) http://www.openstreetmap.org/?lat=39.874594&lon=-75.274415
+MorAve http://www.openstreetmap.org/?lat=39.851030&lon=-75.353304
+SteAve +SteLn http://www.openstreetmap.org/?lat=39.865566&lon=-75.316740
+PA420 http://www.openstreetmap.org/?lat=39.866709&lon=-75.300674
+I-95(10) http://www.openstreetmap.org/?lat=39.874562&lon=-75.274506
 ScoWay http://www.openstreetmap.org/?lat=39.875258&lon=-75.261927
 I-95(12) http://www.openstreetmap.org/?lat=39.882663&lon=-75.252399
-IslAve_N http://www.openstreetmap.org/?lat=39.894616&lon=-75.236650
+IslAve_N http://www.openstreetmap.org/?lat=39.894619&lon=-75.236698
 I-95(13) http://www.openstreetmap.org/?lat=39.892398&lon=-75.235341
-IslAve_S http://www.openstreetmap.org/?lat=39.889797&lon=-75.233731
+IslAve_S http://www.openstreetmap.org/?lat=39.889678&lon=-75.233712
 I-95(14) http://www.openstreetmap.org/?lat=39.892184&lon=-75.224140
-NewYardHwy http://www.openstreetmap.org/?lat=39.905765&lon=-75.193884
-I-76 https://www.openstreetmap.org/?lat=39.913398&lon=-75.181332
+26thSt  +NewYardHwy http://www.openstreetmap.org/?lat=39.905749&lon=-75.193914
+I-76 http://www.openstreetmap.org/?lat=39.913398&lon=-75.181332

--- a/hwy_data/PA/usapa/pa.pa420.wpt
+++ b/hwy_data/PA/usapa/pa.pa420.wpt
@@ -1,6 +1,7 @@
-PA291 https://www.openstreetmap.org/?lat=39.866710&lon=-75.300658
-I-95 https://www.openstreetmap.org/?lat=39.870881&lon=-75.301301
-US13 https://www.openstreetmap.org/?lat=39.882573&lon=-75.306022
-McDBlvd http://www.openstreetmap.org/?lat=39.895917&lon=-75.315249
-BalPk http://www.openstreetmap.org/?lat=39.916970&lon=-75.333467
+PA291 http://www.openstreetmap.org/?lat=39.866709&lon=-75.300674
+I-95 http://www.openstreetmap.org/?lat=39.870881&lon=-75.301301
+US13 http://www.openstreetmap.org/?lat=39.882497&lon=-75.306033
+PA420AltTrkRid_S http://www.openstreetmap.org/?lat=39.895841&lon=-75.315219
+PA420AltTrkPro_N http://www.openstreetmap.org/?lat=39.908162&lon=-75.327458
+BalPk http://www.openstreetmap.org/?lat=39.916937&lon=-75.333485
 PA320 http://www.openstreetmap.org/?lat=39.933867&lon=-75.352360

--- a/hwy_data/PA/usapa/pa.pa420alttrkpro.wpt
+++ b/hwy_data/PA/usapa/pa.pa420alttrkpro.wpt
@@ -2,5 +2,5 @@ PA420_S http://www.openstreetmap.org/?lat=39.870881&lon=-75.301301
 I-95(8) http://www.openstreetmap.org/?lat=39.870980&lon=-75.323312
 US13_S http://www.openstreetmap.org/?lat=39.873870&lon=-75.326208
 US13_N http://www.openstreetmap.org/?lat=39.876503&lon=-75.321126
-McDBlvd http://www.openstreetmap.org/?lat=39.886354&lon=-75.331112
+PA420AltTrk_Rid http://www.openstreetmap.org/?lat=39.886354&lon=-75.331112
 PA420_N http://www.openstreetmap.org/?lat=39.908162&lon=-75.327458

--- a/hwy_data/PA/usapa/pa.pa420alttrkpro.wpt
+++ b/hwy_data/PA/usapa/pa.pa420alttrkpro.wpt
@@ -1,0 +1,6 @@
+PA420_S http://www.openstreetmap.org/?lat=39.870881&lon=-75.301301
+I-95(8) http://www.openstreetmap.org/?lat=39.870980&lon=-75.323312
+US13_S http://www.openstreetmap.org/?lat=39.873870&lon=-75.326208
+US13_N http://www.openstreetmap.org/?lat=39.876503&lon=-75.321126
+McDBlvd http://www.openstreetmap.org/?lat=39.886354&lon=-75.331112
+PA420_N http://www.openstreetmap.org/?lat=39.908162&lon=-75.327458

--- a/hwy_data/PA/usapa/pa.pa420alttrkrid.wpt
+++ b/hwy_data/PA/usapa/pa.pa420alttrkrid.wpt
@@ -1,0 +1,2 @@
+PA420_S http://www.openstreetmap.org/?lat=39.895841&lon=-75.315219
+PA420AltTrk_Pro http://www.openstreetmap.org/?lat=39.886354&lon=-75.331112

--- a/hwy_data/PA/usapa/pa.pa452.wpt
+++ b/hwy_data/PA/usapa/pa.pa452.wpt
@@ -1,5 +1,7 @@
 US13 http://www.openstreetmap.org/?lat=39.819948&lon=-75.417227
 I-95 http://www.openstreetmap.org/?lat=39.833877&lon=-75.424275
-US322 https://www.openstreetmap.org/?lat=39.845976&lon=-75.425692
-US1 https://www.openstreetmap.org/?lat=39.912296&lon=-75.439703
+US322 http://www.openstreetmap.org/?lat=39.845954&lon=-75.425670
+DutMillRd http://www.openstreetmap.org/?lat=39.857090&lon=-75.426952
+ConRd http://www.openstreetmap.org/?lat=39.868909&lon=-75.428403
+US1 http://www.openstreetmap.org/?lat=39.912296&lon=-75.439703
 PA352 http://www.openstreetmap.org/?lat=39.917519&lon=-75.440114

--- a/hwy_data/PA/usapa/pa.pa452.wpt
+++ b/hwy_data/PA/usapa/pa.pa452.wpt
@@ -1,4 +1,4 @@
-US13 https://www.openstreetmap.org/?lat=39.819946&lon=-75.417237
+US13 http://www.openstreetmap.org/?lat=39.819948&lon=-75.417227
 I-95 http://www.openstreetmap.org/?lat=39.833877&lon=-75.424275
 US322 https://www.openstreetmap.org/?lat=39.845976&lon=-75.425692
 US1 https://www.openstreetmap.org/?lat=39.912296&lon=-75.439703

--- a/hwy_data/PA/usaus/pa.us001.wpt
+++ b/hwy_data/PA/usaus/pa.us001.wpt
@@ -37,7 +37,7 @@ RobAve http://www.openstreetmap.org/?lat=40.018708&lon=-75.165839
 PA611 http://www.openstreetmap.org/?lat=40.019787&lon=-75.148906
 US13_S http://www.openstreetmap.org/?lat=40.019612&lon=-75.144060
 AdaAve http://www.openstreetmap.org/?lat=40.029765&lon=-75.103690
-PA232 http://www.openstreetmap.org/?lat=40.031673&lon=-75.084729
+PA232 http://www.openstreetmap.org/?lat=40.031685&lon=-75.084729
 US13_N http://www.openstreetmap.org/?lat=40.034942&lon=-75.071018
 PA73 http://www.openstreetmap.org/?lat=40.044487&lon=-75.054364
 PA532 http://www.openstreetmap.org/?lat=40.074451&lon=-75.034904

--- a/hwy_data/PA/usaus/pa.us001.wpt
+++ b/hwy_data/PA/usaus/pa.us001.wpt
@@ -54,7 +54,7 @@ I-295 +I-95 http://www.openstreetmap.org/?lat=40.193036&lon=-74.879551
 OxfValRd http://www.openstreetmap.org/?lat=40.193397&lon=-74.864981
 StoHillRd http://www.openstreetmap.org/?lat=40.194971&lon=-74.827344
 US1BusPen_N http://www.openstreetmap.org/?lat=40.194487&lon=-74.816487
-US13 +US13_End http://www.openstreetmap.org/?lat=40.196806&lon=-74.802089
+US13 +US13_End http://www.openstreetmap.org/?lat=40.196763&lon=-74.802097
 PA32 http://www.openstreetmap.org/?lat=40.197773&lon=-74.792669
 PenAve http://www.openstreetmap.org/?lat=40.205919&lon=-74.774537
 PA/NJ http://www.openstreetmap.org/?lat=40.209172&lon=-74.767617

--- a/hwy_data/PA/usaus/pa.us013.wpt
+++ b/hwy_data/PA/usaus/pa.us013.wpt
@@ -1,16 +1,18 @@
-DE/PA http://www.openstreetmap.org/?lat=39.811866&lon=-75.433331
-PA452 http://www.openstreetmap.org/?lat=39.819946&lon=-75.417237
-PA291 http://www.openstreetmap.org/?lat=39.828688&lon=-75.400651
-4thSt_E http://www.openstreetmap.org/?lat=39.832622&lon=-75.391767
-9thSt_W http://www.openstreetmap.org/?lat=39.835939&lon=-75.395072
-US322 http://www.openstreetmap.org/?lat=39.842088&lon=-75.384665
-KerSt http://www.openstreetmap.org/?lat=39.848316&lon=-75.371404
+DE/PA http://www.openstreetmap.org/?lat=39.811892&lon=-75.433301
+PA452 http://www.openstreetmap.org/?lat=39.819948&lon=-75.417227
+PA291 http://www.openstreetmap.org/?lat=39.828721&lon=-75.400659
+4thSt_E http://www.openstreetmap.org/?lat=39.832629&lon=-75.391716
+9thSt_W http://www.openstreetmap.org/?lat=39.835932&lon=-75.395053
+US322 http://www.openstreetmap.org/?lat=39.842078&lon=-75.384635
+KerSt http://www.openstreetmap.org/?lat=39.848320&lon=-75.371422
 PA352 http://www.openstreetmap.org/?lat=39.852718&lon=-75.360691
 PA320 http://www.openstreetmap.org/?lat=39.853733&lon=-75.357936
-SteAve http://www.openstreetmap.org/?lat=39.873912&lon=-75.326214
-PA420 http://www.openstreetmap.org/?lat=39.882573&lon=-75.306022
-OakLn http://www.openstreetmap.org/?lat=39.903514&lon=-75.283213
-SprRd http://www.openstreetmap.org/?lat=39.918393&lon=-75.264802
+9thSt_E http://www.openstreetmap.org/?lat=39.855352&lon=-75.353583
+PA420AltTrk_S +SteAve http://www.openstreetmap.org/?lat=39.873870&lon=-75.326208
+PA420AltTrk_N http://www.openstreetmap.org/?lat=39.876503&lon=-75.321126
+PA420 http://www.openstreetmap.org/?lat=39.882497&lon=-75.306033
+OakLn http://www.openstreetmap.org/?lat=39.903490&lon=-75.283223
+SprRd http://www.openstreetmap.org/?lat=39.918364&lon=-75.264735
 ChuLn_S +ChuLn http://www.openstreetmap.org/?lat=39.928440&lon=-75.246544
 BalPk_W +BalAve http://www.openstreetmap.org/?lat=39.941102&lon=-75.256130
 CobCrePkwy http://www.openstreetmap.org/?lat=39.945867&lon=-75.240316
@@ -19,18 +21,22 @@ UniAve http://www.openstreetmap.org/?lat=39.949591&lon=-75.199675
 PA3 http://www.openstreetmap.org/?lat=39.955153&lon=-75.198401
 PowAve_W http://www.openstreetmap.org/?lat=39.959563&lon=-75.197124
 34thSt http://www.openstreetmap.org/?lat=39.960287&lon=-75.190167
-US30 http://www.openstreetmap.org/?lat=39.975180&lon=-75.195107
-33rdSt http://www.openstreetmap.org/?lat=39.975418&lon=-75.189829
-RidAve_N http://www.openstreetmap.org/?lat=40.000728&lon=-75.186782
+I-76/30 +US30 http://www.openstreetmap.org/?lat=39.975213&lon=-75.194491
+GirAve_E +33rdSt http://www.openstreetmap.org/?lat=39.975402&lon=-75.189920
+RidAve_S http://www.openstreetmap.org/?lat=39.992743&lon=-75.186160
+RidAve_N http://www.openstreetmap.org/?lat=40.000391&lon=-75.186927
+AllAve http://www.openstreetmap.org/?lat=40.004940&lon=-75.178810
+FoxSt http://www.openstreetmap.org/?lat=40.007929&lon=-75.172239
+WisAve http://www.openstreetmap.org/?lat=40.009893&lon=-75.166875
 PA611 http://www.openstreetmap.org/?lat=40.017998&lon=-75.149301
 US1_S http://www.openstreetmap.org/?lat=40.019612&lon=-75.144060
 AdaAve http://www.openstreetmap.org/?lat=40.029765&lon=-75.103690
-PA232 http://www.openstreetmap.org/?lat=40.031673&lon=-75.084729
+PA232 http://www.openstreetmap.org/?lat=40.031685&lon=-75.084729
 US1_N http://www.openstreetmap.org/?lat=40.034942&lon=-75.071018
-FraAve_W http://www.openstreetmap.org/?lat=40.028173&lon=-75.059023
+FraAve_W http://www.openstreetmap.org/?lat=40.028103&lon=-75.058916
 PA73 http://www.openstreetmap.org/?lat=40.036762&lon=-75.040859
-WilRd http://www.openstreetmap.org/?lat=40.052453&lon=-75.007911
-KniRd http://www.openstreetmap.org/?lat=40.064902&lon=-74.982290
+AcaRd +WilRd http://www.openstreetmap.org/?lat=40.052351&lon=-75.007935
+KniRd http://www.openstreetmap.org/?lat=40.064693&lon=-74.982271
 PA63 http://www.openstreetmap.org/?lat=40.072934&lon=-74.963003
 PA513 http://www.openstreetmap.org/?lat=40.075093&lon=-74.958877
 PA132 +StrRd http://www.openstreetmap.org/?lat=40.084144&lon=-74.935201
@@ -38,9 +44,9 @@ US13AltTrk_N http://www.openstreetmap.org/?lat=40.091295&lon=-74.923810
 PA413 http://www.openstreetmap.org/?lat=40.098477&lon=-74.873902
 BathRd +BethRd http://www.openstreetmap.org/?lat=40.102108&lon=-74.863337
 I-95 +I-276 http://www.openstreetmap.org/?lat=40.117477&lon=-74.845935
-BriPk_N http://www.openstreetmap.org/?lat=40.145256&lon=-74.814019
-MilCrkRd http://www.openstreetmap.org/?lat=40.157885&lon=-74.812217
-PenVlyRd http://www.openstreetmap.org/?lat=40.171561&lon=-74.812431
-NewTybRd http://www.openstreetmap.org/?lat=40.181398&lon=-74.808912
-LowMorRd http://www.openstreetmap.org/?lat=40.193627&lon=-74.801273
-US1 http://www.openstreetmap.org/?lat=40.196806&lon=-74.802089
+BriPk_N http://www.openstreetmap.org/?lat=40.143233&lon=-74.815390
+MilCrkRd http://www.openstreetmap.org/?lat=40.157816&lon=-74.812155
+PenValRd http://www.openstreetmap.org/?lat=40.171528&lon=-74.812458
+TybRd http://www.openstreetmap.org/?lat=40.181343&lon=-74.808939
+LowMorRd http://www.openstreetmap.org/?lat=40.193621&lon=-74.801263
+US1 http://www.openstreetmap.org/?lat=40.196763&lon=-74.802097

--- a/hwy_data/PA/usaus/pa.us322.wpt
+++ b/hwy_data/PA/usaus/pa.us322.wpt
@@ -195,7 +195,7 @@ PA926 http://www.openstreetmap.org/?lat=39.919743&lon=-75.576925
 US1/202 +US1_S http://www.openstreetmap.org/?lat=39.880964&lon=-75.546726
 US1_N http://www.openstreetmap.org/?lat=39.885570&lon=-75.528045
 PA261 http://www.openstreetmap.org/?lat=39.858162&lon=-75.477018
-PA452 http://www.openstreetmap.org/?lat=39.845976&lon=-75.425692
+PA452 http://www.openstreetmap.org/?lat=39.845954&lon=-75.425670
 I-95(3) http://www.openstreetmap.org/?lat=39.841001&lon=-75.404277
 I-95(4) http://www.openstreetmap.org/?lat=39.846955&lon=-75.387923
 US13 http://www.openstreetmap.org/?lat=39.842088&lon=-75.384665

--- a/hwy_data/PA/usaus/pa.us322.wpt
+++ b/hwy_data/PA/usaus/pa.us322.wpt
@@ -198,6 +198,6 @@ PA261 http://www.openstreetmap.org/?lat=39.858162&lon=-75.477018
 PA452 http://www.openstreetmap.org/?lat=39.845954&lon=-75.425670
 I-95(3) http://www.openstreetmap.org/?lat=39.841001&lon=-75.404277
 I-95(4) http://www.openstreetmap.org/?lat=39.846955&lon=-75.387923
-US13 http://www.openstreetmap.org/?lat=39.842088&lon=-75.384665
-PA291 http://www.openstreetmap.org/?lat=39.836186&lon=-75.379735
+US13 http://www.openstreetmap.org/?lat=39.842078&lon=-75.384635
+PA291 http://www.openstreetmap.org/?lat=39.836151&lon=-75.379780
 PA/NJ http://www.openstreetmap.org/?lat=39.827984&lon=-75.371296

--- a/hwy_data/PA/usausb/pa.us001buspen.wpt
+++ b/hwy_data/PA/usausb/pa.us001buspen.wpt
@@ -8,4 +8,4 @@ OxfValRd http://www.openstreetmap.org/?lat=40.180677&lon=-74.870238
 NewTybRd http://www.openstreetmap.org/?lat=40.191496&lon=-74.823761
 US1 http://www.openstreetmap.org/?lat=40.194487&lon=-74.816487
 TreAve http://www.openstreetmap.org/?lat=40.195823&lon=-74.815264
-US1_N http://www.openstreetmap.org/?lat=40.196806&lon=-74.802089
+US1_N http://www.openstreetmap.org/?lat=40.196763&lon=-74.802097

--- a/hwy_data/_systems/usapa.csv
+++ b/hwy_data/_systems/usapa.csv
@@ -295,6 +295,8 @@ usapa;PA;PA417;;;;pa.pa417;
 usapa;PA;PA418;;;;pa.pa418;
 usapa;PA;PA419;;;;pa.pa419;
 usapa;PA;PA420;;;;pa.pa420;
+usapa;PA;PA420;AltTrk;Pro;Prospect Park;pa.pa420alttrkpro;
+usapa;PA;PA420;AltTrk;Rid;Ridley Township;pa.pa420alttrkrid;
 usapa;PA;PA423;;;;pa.pa423;
 usapa;PA;PA424;;;;pa.pa424;
 usapa;PA;PA425;;;;pa.pa425;

--- a/hwy_data/_systems/usapa_con.csv
+++ b/hwy_data/_systems/usapa_con.csv
@@ -294,6 +294,8 @@ usapa;PA417;;;pa.pa417
 usapa;PA418;;;pa.pa418
 usapa;PA419;;;pa.pa419
 usapa;PA420;;;pa.pa420
+usapa;PA420;AltTrk;Prospect Park;pa.pa420alttrkpro
+usapa;PA420;AltTrk;Ridley Township;pa.pa420alttrkrid
 usapa;PA423;;;pa.pa423
 usapa;PA424;;;pa.pa424
 usapa;PA425;;;pa.pa425

--- a/updates.csv
+++ b/updates.csv
@@ -2386,6 +2386,8 @@
 2017-09-06;(USA) Oregon;OR 99;or.or099;Restored route from I-5 onto Yoncalla-Drain routing. 
 2017-09-06;(USA) Oregon;OR 99W;or.or099w;Truncated route from I-5(306) to I-5(294) to reflect signage and prepare for Oregon Highways dataset. 
 2017-09-06;(USA) Oregon;OR 126;or.or126;Moved route from Bus 97 to US 97 in Redmond.
+2018-10-08;(USA) Pennsylvania;PA 420 Alternate Truck (Ridley Township);pa.pa420alttrkrid; Route added 
+2018-10-08;(USA) Pennsylvania;PA 420 Alternate Truck (Prospect Park);pa.pa420alttrkpro; Route added 
 2018-10-08;(USA) Pennsylvania;PA 329 Truck (Northampton);pa.pa329trknor; Route added
 2018-10-03;(USA) Pennsylvania;US 13 Alternate Truck (Bensalem);pa.us013alttrkben; Route added
 2018-09-30;(USA) Pennsylvania;US 6 Business (Carbondale);pa.us006buscar; Renamed and extended west to US 11


### PR DESCRIPTION
Changes from 10-7-2018:
US 13: Added 9thSt_E, PA420AltTrk_N, Girard Ave (GirAve_E), Ridge Ave (RidAve_S(, Allegheny Ave (AllAve), Fox St, and Wissahickon Ave(WisAve)

Lined up with I-76: 342 and US 30: I-76(342).

PA 291: Removed PriSt_S (replaced by +X1) as it is an access to a gated area.  Added Highland Ave(HigAve), Kerlin St (KerSt), Edgemont Ave (EdgAve), and Morton Ave (MorAve).
PA 420: Added points and added PA 420 ALT Trucks (Prospect Park and Ridley Township)

The Prospect Park route bypasses two weight-restricted bridges along PA 420  (second one is SB only) and overlaps with the Ridley Township route north of MacDade Blvd.  This is why the Ridley Township road only goes from PA 420 to the Prospect Park route along MacDade Blvd.
PA 452: Added Duttons Mill Rd (DutMillRd) and Concord Rd (ConRd)
